### PR TITLE
Fix the circleci build issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - checkout
     - setup_remote_docker:
-          docker_layer_caching: true
+          docker_layer_caching: false
     - run:
         name: run tests
         command: |


### PR DESCRIPTION
Fix build issue due to docker cache unavailable: https://discuss.circleci.com/t/blocked-due-to-free-plan-docker-layer-caching-unavailable-but-i-dont-build-docker-images/32844