### PR TITLE
Fix for kubernetes 1.17 and clarify some documentaion

### DIFF
--- a/config/gpushare-schd-extender.yaml
+++ b/config/gpushare-schd-extender.yaml
@@ -61,7 +61,7 @@ subjects:
 # deployment yaml
 ---
 kind: Deployment
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 metadata:
   name: gpushare-schd-extender
   namespace: kube-system

--- a/config/gpushare-schd-extender.yaml
+++ b/config/gpushare-schd-extender.yaml
@@ -69,6 +69,10 @@ spec:
   replicas: 1
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+        app: gpushare
+        component: gpushare-schd-extender
   template:
     metadata:
       labels:

--- a/docs/install.md
+++ b/docs/install.md
@@ -20,7 +20,7 @@ Enable the Nvidia runtime as your default runtime on your node. To do this, plea
 
 > *if `runtimes` is not already present, head to the install page of [nvidia-docker](https://github.com/NVIDIA/nvidia-docker)*
 
-## 1\. Deploy GPU share scheduler extender
+## 1\. Deploy GPU share scheduler extender in control plane
 
 ```bash
 cd /etc/kubernetes/
@@ -32,7 +32,7 @@ kubectl create -f gpushare-schd-extender.yaml
 
 ## 2\. Modify scheduler configuration
 The goal is to include `/etc/kubernetes/scheduler-policy-config.json` into the scheduler configuration (`/etc/kubernetes/manifests/kube-scheduler.yaml`).
-Here is the sample of the modified [kube-scheduler.yaml](../config/kube-scheduler.yaml)
+Here is the sample of the final modified [kube-scheduler.yaml](../config/kube-scheduler.yaml)
 
 > Notice: If your Kubernetes default scheduler is deployed as static pod, don't edit the yaml file inside /etc/kubernetes/manifest. You need to edit the yaml file outside the `/etc/kubernetes/manifest` directory. and copy the yaml file you edited to the '/etc/kubernetes/manifest/' directory, and then kubernetes will update the default static pod with the yaml file automatically.
 
@@ -77,7 +77,7 @@ kubectl label node <target_node> gpushare=true
 For example:
 
 ```bash
-kubectl label no mynode gpushare=true
+kubectl label node mynode gpushare=true
 ```
 
 ## 5\. Install Kubectl extension


### PR DESCRIPTION
https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

In particular, Deployment in the extensions/v1beta1, apps/v1beta1, and apps/v1beta2 API versions is no longer served.

Also, spec.selector is now required and immutable after creation

Documentation is also now improved to indicate that it is actually done only for the control plane.